### PR TITLE
Generate stats JSON in Yosys RTL commands

### DIFF
--- a/src/project/yosys.ts
+++ b/src/project/yosys.ts
@@ -85,6 +85,7 @@ export const generateYosysRTLCommands = (inputFiles: string[]): string[] => {
         'memory -nomap;',
         'wreduce -memx;',
         'opt -full;',
+        'tee -q -o stats.digitaljs.json stat -json *;',
         'write_json rtl.digitaljs.json',
         ''
     ];


### PR DESCRIPTION
Adds RTL generation command to write a json file containing statistics to `stats.digitaljs.json`.