### PR TITLE
project: more output file attributes

### DIFF
--- a/src/project/project.ts
+++ b/src/project/project.ts
@@ -4,7 +4,7 @@ import {DEFAULT_CONFIGURATION, type ProjectConfiguration, schemaProjectConfigura
 
 type ProjectTarget = ProjectConfiguration['targets'][number];
 
-interface ProjectOutputFileState {
+export interface ProjectOutputFileState {
     path: string;
     targetId: string | null;
     stale: boolean;

--- a/src/project/project.ts
+++ b/src/project/project.ts
@@ -2,28 +2,89 @@ import {decodeJSON, encodeJSON} from '../util.js';
 
 import {DEFAULT_CONFIGURATION, type ProjectConfiguration, schemaProjectConfiguration} from './configuration.js';
 
+type ProjectTarget = ProjectConfiguration['targets'][number];
+
+interface ProjectOutputFileState {
+    path: string;
+    targetId: string | null;
+    stale: boolean;
+}
+
+class ProjectOutputFile {
+    constructor(
+        private _project: Project,
+        private _path: string,
+        private _targetId: string | null = null,
+        private _stale: boolean = false
+    ) {}
+
+    get path(): string {
+        return this._path;
+    }
+
+    get targetId(): string | null {
+        return this._targetId;
+    }
+
+    set targetId(id: string | null) {
+        if (id !== null && this._project.getTarget(id) === null) {
+            throw new Error(`Invalid target id: ${id}`);
+        }
+        this._targetId = id;
+    }
+
+    get target(): ProjectTarget | null {
+        if (!this._targetId) return null;
+        return this._project.getTarget(this._targetId);
+    }
+
+    get stale(): boolean {
+        return this._stale;
+    }
+
+    static serialize(file: ProjectOutputFile): ProjectOutputFileState {
+        return {
+            path: file.path,
+            targetId: file.targetId,
+            stale: file.stale
+        };
+    }
+
+    static deserialize(project: Project, data: ProjectOutputFileState | string, ..._args: unknown[]) {
+        // Older versions of this module (<= 0.3.6) stored output files as an array of paths instead,
+        // so we need to migrate if data is a string (single output file).
+        if (typeof data === 'string') {
+            data = {path: data, targetId: null, stale: false};
+        }
+
+        return new ProjectOutputFile(project, data.path, data.targetId, data.stale);
+    }
+}
+
 export interface ProjectState {
     name: string;
     inputFiles: string[];
-    outputFiles: string[];
+    outputFiles: ProjectOutputFileState[] | string[];
     configuration: ProjectConfiguration;
 }
 
 export class Project {
     private name: string;
     private inputFiles: string[];
-    private outputFiles: string[];
+    private outputFiles: ProjectOutputFile[];
     private configuration: ProjectConfiguration;
 
     constructor(
         name: string,
         inputFiles: string[] = [],
-        outputFiles: string[] = [],
+        outputFiles: ProjectOutputFileState[] | string[] = [],
         configuration: ProjectConfiguration = DEFAULT_CONFIGURATION
     ) {
         this.name = name;
         this.inputFiles = inputFiles;
-        this.outputFiles = outputFiles;
+        this.outputFiles = outputFiles.map((file: ProjectOutputFileState | string) =>
+            ProjectOutputFile.deserialize(this, file)
+        );
 
         const config = schemaProjectConfiguration.safeParse(configuration);
         if (config.success) {
@@ -66,14 +127,16 @@ export class Project {
     }
 
     hasOutputFile(filePath: string) {
-        return this.outputFiles.some((file) => file === filePath);
+        return this.outputFiles.some((file) => file.path === filePath);
     }
 
-    addOutputFiles(filePaths: string[]) {
-        for (const filePath of filePaths) {
-            if (!this.hasOutputFile(filePath)) {
-                this.outputFiles.push(filePath);
-            }
+    addOutputFiles(files: {path: string; targetId: string}[]) {
+        for (const file of files) {
+            if (this.hasOutputFile(file.path)) continue;
+
+            const outputFile = new ProjectOutputFile(this, file.path, file.targetId);
+            if (outputFile.target === null) throw new Error(`Invalid target ID: ${file.targetId}`);
+            this.outputFiles.push(outputFile);
         }
 
         this.outputFiles.sort((a, b) => {
@@ -82,7 +145,7 @@ export class Project {
     }
 
     removeOutputFiles(filePaths: string[]) {
-        this.outputFiles = this.outputFiles.filter((file) => !filePaths.includes(file));
+        this.outputFiles = this.outputFiles.filter((file) => !filePaths.includes(file.path));
     }
 
     getConfiguration() {
@@ -96,11 +159,16 @@ export class Project {
         };
     }
 
+    getTarget(id: string): ProjectTarget | null {
+        const targets = this.configuration.targets;
+        return targets.find((target) => target.id === id) ?? null;
+    }
+
     static serialize(project: Project): ProjectState {
         return {
             name: project.name,
             inputFiles: project.inputFiles,
-            outputFiles: project.outputFiles,
+            outputFiles: project.outputFiles.map((file) => ProjectOutputFile.serialize(file)),
             configuration: project.configuration
         };
     }
@@ -108,7 +176,7 @@ export class Project {
     static deserialize(data: ProjectState, ..._args: unknown[]): Project {
         const name: string = data.name;
         const inputFiles: string[] = data.inputFiles ?? [];
-        const outputFiles: string[] = data.outputFiles ?? [];
+        const outputFiles: ProjectOutputFileState[] | string[] = data.outputFiles ?? [];
         const configuration: ProjectConfiguration = data.configuration ?? {};
 
         return new Project(name, inputFiles, outputFiles, configuration);

--- a/src/project/project.ts
+++ b/src/project/project.ts
@@ -166,6 +166,12 @@ export class Project {
         this.outputFiles = this.outputFiles.filter((file) => !filePaths.includes(file.path));
     }
 
+    expireOutputFiles() {
+        for (const file of this.outputFiles) {
+            file.stale = true;
+        }
+    }
+
     getConfiguration() {
         return this.configuration;
     }

--- a/src/project/project.ts
+++ b/src/project/project.ts
@@ -172,6 +172,11 @@ export class Project {
             ...this.configuration,
             ...configuration
         };
+
+        // Unset 'lingering' output file target IDs
+        for (const outFile of this.outputFiles) {
+            if (!outFile.target) outFile.targetId = null;
+        }
     }
 
     getTarget(id: string): ProjectTarget | null {

--- a/src/project/project.ts
+++ b/src/project/project.ts
@@ -96,6 +96,9 @@ export class Project {
         } else {
             throw new Error(`Failed to parse project configuration: ${config.error.toString()}`);
         }
+
+        // Trigger a config 'update' to deploy any modifications it might want to make
+        this.updateConfiguration({});
     }
 
     getName() {

--- a/src/project/project.ts
+++ b/src/project/project.ts
@@ -42,6 +42,10 @@ export class ProjectOutputFile {
         return this._stale;
     }
 
+    set stale(isStale: boolean) {
+        this._stale = isStale;
+    }
+
     static serialize(file: ProjectOutputFile): ProjectOutputFileState {
         return {
             path: file.path,
@@ -136,7 +140,14 @@ export class Project {
 
     addOutputFiles(files: {path: string; targetId: string}[]) {
         for (const file of files) {
-            if (this.hasOutputFile(file.path)) continue;
+            const existingOutFile = this.getOutputFile(file.path);
+            if (existingOutFile) {
+                // File already exists, so we don't want to add it again.
+                // But, we should make sure the target ID gets updated and set `stale` to false.
+                existingOutFile.targetId = file.targetId;
+                existingOutFile.stale = false;
+                continue;
+            }
 
             const outputFile = new ProjectOutputFile(this, file.path, file.targetId);
             if (outputFile.target === null) throw new Error(`Invalid target ID: ${file.targetId}`);

--- a/src/project/project.ts
+++ b/src/project/project.ts
@@ -10,7 +10,7 @@ export interface ProjectOutputFileState {
     stale: boolean;
 }
 
-class ProjectOutputFile {
+export class ProjectOutputFile {
     constructor(
         private _project: Project,
         private _path: string,

--- a/src/project/project.ts
+++ b/src/project/project.ts
@@ -126,8 +126,12 @@ export class Project {
         return this.outputFiles;
     }
 
-    hasOutputFile(filePath: string) {
-        return this.outputFiles.some((file) => file.path === filePath);
+    hasOutputFile(filePath: string): boolean {
+        return this.getOutputFile(filePath) !== null;
+    }
+
+    getOutputFile(filePath: string): ProjectOutputFile | null {
+        return this.outputFiles.find((file) => file.path === filePath) ?? null;
     }
 
     addOutputFiles(files: {path: string; targetId: string}[]) {


### PR DESCRIPTION
Adds the following additional attributes to project output files:
- `targetId`: indicates the target configuration that generated this output file
- `stale`: indicates whether the output file is 'stale'. An output file is marked as stale if the input files that were used to generate it were modified.

TODO:
- [x] Add attributes to output files
- [x] Migration path for old config
  - Old configs (`string[]`-style paths) are converted by setting `targetId` to `null` and `stale` to `false`.
- [x] Update output files when target IDs change
  - Properly updating this would involve making the project configuration stateful, which is a big task on its own and out of scope for this PR. For now, setting the `targetId` to `null` when the configuration is modified is sufficient.
- [ ] Mark files as stale when input files have been updated
  - On second thought, this should probably be handled in the extension instead. We should not set filesystem listeners in this module.
